### PR TITLE
Add CPU pinning module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(folly REQUIRED)
 find_package(Boost COMPONENTS iostreams REQUIRED)
 set(BOOST_LIBS Boost::iostreams ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_LIBRARIES})
 
-daq_codegen( TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
+daq_codegen( cpupinner.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
 daq_codegen( *info.jsonnet DEP_PKGS opmonlib TEMPLATES opmonlib/InfoStructs.hpp.j2 opmonlib/InfoNljs.hpp.j2 )
 
 ##############################################################################
@@ -61,6 +61,7 @@ daq_add_plugin(FragmentConsumer duneDAQModule LINK_LIBRARIES readoutmodules)
 daq_add_plugin(TimeSyncConsumer duneDAQModule LINK_LIBRARIES readoutmodules)
 daq_add_plugin(ErroredFrameConsumer duneDAQModule LINK_LIBRARIES readoutmodules)
 daq_add_plugin(FragmentSender duneDAQModule LINK_LIBRARIES readoutmodules)
+daq_add_plugin(CPUPinner duneDAQModule LINK_LIBRARIES readoutmodules)
 
 ##############################################################################
 # Integration tests

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Before running the application, please download a small binary file that contain
 
     curl https://cernbox.cern.ch/index.php/s/7qNnuxD8igDOVJT/download -o frames.bin
 
+**Remark for software TPG**: In order to make the software TPG producing meaningful output, use a frame file from the directory described in the [Software TPG section](#enabling-the-software-tpg)!
     
 For WIB2 frames, download the following file that contains 120 WIB-2 Frames from the following [CERNBox link](https://cernbox.cern.ch/index.php/s/ocrHxSU8PucxphE), or like so:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,6 @@ How to clone and build DUNE DAQ packages, including `readoutmodules`, is covered
 Before running the application, please download a small binary file that contains WIB Frames from the following [CERNBox link](https://cernbox.cern.ch/index.php/s/7qNnuxD8igDOVJT), or from the commandline:
 
     curl https://cernbox.cern.ch/index.php/s/7qNnuxD8igDOVJT/download -o frames.bin
-
-**Remark for software TPG**: In order to make the software TPG producing meaningful output, use a frame file from the directory described in the [Software TPG section](#enabling-the-software-tpg)!
     
 For WIB2 frames, download the following file that contains 120 WIB-2 Frames from the following [CERNBox link](https://cernbox.cern.ch/index.php/s/ocrHxSU8PucxphE), or like so:
 

--- a/plugins/CPUPinner.cpp
+++ b/plugins/CPUPinner.cpp
@@ -1,0 +1,136 @@
+/**
+ * @file CPUPinner.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2021.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "CPUPinner.hpp"
+
+#include "logging/Logging.hpp"
+
+#include <chrono>
+#include <sstream>
+#include <string>
+#include <filesystem>
+#include <fstream>
+
+namespace dunedaq {
+namespace readoutmodules {
+CPUPinner::CPUPinner(const std::string& name)
+  : DAQModule(name)
+  , m_thread(std::bind(&CPUPinner::do_work, this, std::placeholders::_1))
+{
+
+  register_command("conf", &CPUPinner::do_conf);
+  register_command("start", &CPUPinner::do_start);
+  register_command("stop", &CPUPinner::do_stop);
+  register_command("scrap", &CPUPinner::do_scrap);
+}
+
+void
+CPUPinner::init(const nlohmann::json&)
+{}
+
+void
+CPUPinner::get_info(opmonlib::InfoCollector& /* ci */, int /*level*/)
+{}
+
+void
+CPUPinner::do_conf(const nlohmann::json& conf)
+{
+  m_conf = conf.get<cpupinner::Conf>();
+  TLOG_DEBUG(2) << get_name() + " configured.";
+}
+
+void
+CPUPinner::do_start(const nlohmann::json& /* args */)
+{
+  m_thread.start_working_thread("pinner");
+  TLOG_DEBUG(2) << get_name() + " successfully started.";
+}
+
+void
+CPUPinner::do_stop(const nlohmann::json&)
+{
+  m_thread.stop_working_thread();
+  TLOG_DEBUG(2) << get_name() + " successfully stopped.";
+}
+
+void
+CPUPinner::do_scrap(const nlohmann::json&)
+{}
+
+void
+CPUPinner::do_work(std::atomic<bool>& running_flag)
+{
+  size_t n_threads_to_pin = m_conf.thread_confs.size();
+  size_t n_threads_pinned = 0;
+  while (running_flag.load()) {
+    // Loop over the requested threads to pin. If we find a thread
+    // with the given name, pin it and remove it from the list so we don't try it again next time
+    for (auto it = m_conf.thread_confs.begin(); it != m_conf.thread_confs.end(); ) {
+      int tid = tid_for_name(it->name);
+      if (tid >= 0) {
+        std::stringstream ss;
+        for(auto cpu: it->cpu_set) {
+          ss << cpu << ", ";
+        }
+        TLOG_DEBUG(1) << "Pinning thread name " << it->name << ", tid " << tid << " to CPUs " << ss.str();
+        pin_thread(tid, it->cpu_set);
+        it = m_conf.thread_confs.erase(it);
+        ++n_threads_pinned;
+      } else {
+        ++it;
+      }
+    }
+    // No more threads to pin, so no need to keep looping
+    if (m_conf.thread_confs.empty()) {
+      TLOG() << "No more threads to pin. Exiting loop";
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+        
+  } // while (running_flag.load())
+
+  TLOG() << get_name() << ": do_work() done. Pinned " << n_threads_pinned << " out of " << n_threads_to_pin << " requested";
+}
+
+// pin the thread with thread ID `tid` to the set of CPUs in `cpus`
+void
+CPUPinner::pin_thread(int tid, std::vector<int> cpus) const
+{
+  cpu_set_t cpuset;
+  CPU_ZERO(&cpuset);
+  for (int cpu : cpus) {
+    CPU_SET(cpu, &cpuset);
+  }
+  sched_setaffinity(tid, sizeof(cpu_set_t), &cpuset);
+}
+
+// Get the thread ID for the thread in the current process that has
+// name `name`. Returns -1 if no such thread found
+int
+CPUPinner::tid_for_name(std::string name) const
+{
+  // /proc/self/task contains a directory for every thread in the
+  // current process (including the main thread). The directory name
+  // is the thread ID. The thread name is stored in the `comm` file
+  // in the thread's directory
+  for (auto const& dir_entry : std::filesystem::directory_iterator{ "/proc/self/task" }) {
+    std::filesystem::path name_file = dir_entry.path() / "comm";
+    std::ifstream fin(name_file);
+    std::string thread_name;
+    fin >> thread_name;
+    if (thread_name == name) {
+      return std::stoi(dir_entry.path().filename());
+    }
+  }
+  return -1;
+}
+
+} // namespace readoutmodules
+} // namespace dunedaq
+
+DEFINE_DUNE_DAQ_MODULE(dunedaq::readoutmodules::CPUPinner)

--- a/plugins/CPUPinner.hpp
+++ b/plugins/CPUPinner.hpp
@@ -1,0 +1,53 @@
+/**
+ * @file CPUPinner.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2021.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef READOUTMODULES_PLUGINS_CPUPINNER_HPP_
+#define READOUTMODULES_PLUGINS_CPUPINNER_HPP_
+
+#include "appfwk/DAQModule.hpp"
+
+#include "utilities/WorkerThread.hpp"
+
+#include "readoutmodules/cpupinner/Nljs.hpp"
+
+namespace dunedaq {
+namespace readoutmodules {
+class CPUPinner : public dunedaq::appfwk::DAQModule
+{
+public:
+  explicit CPUPinner(const std::string& name);
+
+  CPUPinner(const CPUPinner&) = delete;
+  CPUPinner& operator=(const CPUPinner&) = delete;
+  CPUPinner(CPUPinner&&) = delete;
+  CPUPinner& operator=(CPUPinner&&) = delete;
+
+  void init(const nlohmann::json& iniobj) override;
+  void get_info(opmonlib::InfoCollector& ci, int level) override;
+
+private:
+  void do_conf(const nlohmann::json& config);
+  void do_start(const nlohmann::json& obj);
+  void do_stop(const nlohmann::json& obj);
+  void do_scrap(const nlohmann::json& obj);
+  void do_work(std::atomic<bool>&);
+
+  // pin the thread with thread ID `tid` to the set of CPUs in `cpus`
+  void pin_thread(int tid, std::vector<int> cpus) const;
+
+  // Get the thread ID for the thread in the current process that has
+  // name `name`. Returns -1 if no such thread found
+  int tid_for_name(std::string name) const;
+
+  dunedaq::utilities::WorkerThread m_thread;
+  cpupinner::Conf m_conf;
+};
+} // namespace readoutmodules
+} // namespace dunedaq
+
+#endif // READOUTMODULES_PLUGINS_CPUPINNER_HPP_

--- a/schema/readoutmodules/cpupinner.jsonnet
+++ b/schema/readoutmodules/cpupinner.jsonnet
@@ -1,0 +1,36 @@
+// The schema used by classes in the appfwk code tests.
+//
+// It is an example of the lowest layer schema below that of the "cmd"
+// and "app" and which defines the final command object structure as
+// consumed by instances of specific DAQModule implementations (ie,
+// the test/Fake* modules).
+
+local moo = import "moo.jsonnet";
+
+// A schema builder in the given path (namespace)
+local ns = "dunedaq.readoutmodules.cpupinner";
+local s = moo.oschema.schema(ns);
+
+// Object structure used by the test/fake producer module
+local cpupinner = {
+  thread_name : s.string("ThreadName",
+    doc="A name of a thread"),
+
+  cpu_id: s.number("CPUID", "i4", doc="A CPU ID"),
+
+  cpu_set: s.sequence("CPUSet", self.cpu_id),
+
+  thread_conf: s.record("ThreadConf", [
+    s.field("name", self.thread_name),
+    s.field("cpu_set", self.cpu_set),
+  ]),
+
+  thread_confs: s.sequence("ThreadConfs", self.thread_conf),
+  
+  cpupinnerconf: s.record("Conf", [
+    s.field("thread_confs", self.thread_confs),
+  ]),
+
+};
+
+moo.oschema.sort_select(cpupinner, ns)


### PR DESCRIPTION
This PR adds a DAQModule that pins threads to CPU cores based on the configuration it's given. This is intended as a short-term solution for v2.10.2 and the spring 2022 VD coldbox tests - how to deal with this issue in the longer term is up for discussion.