### PR TITLE
Add readout implementations for the TDE readout system

### DIFF
--- a/src/CreateReadout.hpp
+++ b/src/CreateReadout.hpp
@@ -31,6 +31,7 @@
 #include "fdreadoutlibs/wib/SWWIBTriggerPrimitiveProcessor.hpp"
 #include "fdreadoutlibs/wib/WIBFrameProcessor.hpp"
 #include "fdreadoutlibs/wib2/WIB2FrameProcessor.hpp"
+#include "fdreadoutlibs/tde/TDEFrameProcessor.hpp"
 #include "ndreadoutlibs/NDReadoutTypes.hpp"
 #include "ndreadoutlibs/pacman/PACMANFrameProcessor.hpp"
 #include "ndreadoutlibs/pacman/PACMANListRequestHandler.hpp"
@@ -153,6 +154,19 @@ createReadout(const nlohmann::json& args, std::atomic<bool>& run_marker)
                                              ndreadoutlibs::PACMANListRequestHandler,
                                              rol::SkipListLatencyBufferModel<ndt::PACMAN_MESSAGE_STRUCT>,
                                              ndreadoutlibs::PACMANFrameProcessor>>(run_marker);
+        readout_model->init(args);
+        return readout_model;
+      }
+
+      // If TDE
+      if (inst.find("tde") != std::string::npos) {
+        TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating readout for TDE";
+        auto readout_model = std::make_unique<
+          rol::ReadoutModel<fdt::TDE_AMC_CHUNK,
+                            rol::DefaultRequestHandlerModel<fdt::TDE_AMC_CHUNK,
+                                                            rol::FixedRateQueueModel<fdt::TDE_AMC_CHUNK>>,
+                            rol::FixedRateQueueModel<fdt::TDE_AMC_CHUNK>,
+                            fdl::TDEFrameProcessor>>(run_marker);
         readout_model->init(args);
         return readout_model;
       }

--- a/src/CreateReadout.hpp
+++ b/src/CreateReadout.hpp
@@ -162,10 +162,10 @@ createReadout(const nlohmann::json& args, std::atomic<bool>& run_marker)
       if (inst.find("tde") != std::string::npos) {
         TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating readout for TDE";
         auto readout_model = std::make_unique<
-          rol::ReadoutModel<fdt::TDE_AMC_CHUNK,
-                            rol::DefaultRequestHandlerModel<fdt::TDE_AMC_CHUNK,
-                                                            rol::FixedRateQueueModel<fdt::TDE_AMC_CHUNK>>,
-                            rol::FixedRateQueueModel<fdt::TDE_AMC_CHUNK>,
+          rol::ReadoutModel<fdt::TDE_AMC_STRUCT,
+                            rol::DefaultRequestHandlerModel<fdt::TDE_AMC_STRUCT,
+                                                            rol::FixedRateQueueModel<fdt::TDE_AMC_STRUCT>>,
+                            rol::FixedRateQueueModel<fdt::TDE_AMC_STRUCT>,
                             fdl::TDEFrameProcessor>>(run_marker);
         readout_model->init(args);
         return readout_model;

--- a/src/CreateSourceEmulator.hpp
+++ b/src/CreateSourceEmulator.hpp
@@ -91,7 +91,7 @@ createSourceEmulator(const iomanager::connection::ConnectionRef qi, std::atomic<
   // IF TDE
   if (inst.find("tde") != std::string::npos) {
     auto source_emu_model =
-      std::make_unique<readoutlibs::TDECrateSourceEmulatorModel<fdreadoutlibs::types::TDE_AMC_CHUNK>>(
+      std::make_unique<readoutlibs::TDECrateSourceEmulatorModel<fdreadoutlibs::types::TDE_AMC_STRUCT>>(
         qi.name, run_marker, tde_time_tick_diff, tde_dropout_rate, emu_frame_error_rate, tde_rate_khz);
     return source_emu_model;
   }

--- a/src/CreateSourceEmulator.hpp
+++ b/src/CreateSourceEmulator.hpp
@@ -14,6 +14,7 @@
 
 #include "readoutlibs/ReadoutLogging.hpp"
 #include "readoutlibs/models/SourceEmulatorModel.hpp"
+#include "readoutlibs/models/TDECrateSourceEmulatorModel.hpp"
 
 #include "fdreadoutlibs/FDReadoutTypes.hpp"
 #include "fdreadoutlibs/wib/TPEmulatorModel.hpp"
@@ -43,6 +44,10 @@ createSourceEmulator(const iomanager::connection::ConnectionRef qi, std::atomic<
   static constexpr int wib2_time_tick_diff = 32;
   static constexpr double wib2_dropout_rate = 0.0;
   static constexpr double wib2_rate_khz = 166.0;
+
+  static constexpr int tde_time_tick_diff = 1000;
+  static constexpr double tde_dropout_rate = 0.0;
+  static constexpr double tde_rate_khz = 0.43668;
 
   static constexpr double emu_frame_error_rate = 0.0;
 
@@ -80,6 +85,14 @@ createSourceEmulator(const iomanager::connection::ConnectionRef qi, std::atomic<
   if (inst.find("tp") != std::string::npos) {
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake tp link";
     auto source_emu_model = std::make_unique<fdreadoutlibs::TPEmulatorModel>(run_marker, 66.0);
+    return source_emu_model;
+  }
+
+  // IF TDE
+  if (inst.find("tde") != std::string::npos) {
+    auto source_emu_model =
+      std::make_unique<readoutlibs::TDECrateSourceEmulatorModel<fdreadoutlibs::types::TDE_AMC_CHUNK>>(
+        qi.name, run_marker, tde_time_tick_diff, tde_dropout_rate, emu_frame_error_rate, tde_rate_khz);
     return source_emu_model;
   }
 

--- a/src/CreateSourceEmulator.hpp
+++ b/src/CreateSourceEmulator.hpp
@@ -14,7 +14,7 @@
 
 #include "readoutlibs/ReadoutLogging.hpp"
 #include "readoutlibs/models/SourceEmulatorModel.hpp"
-#include "readoutlibs/models/TDECrateSourceEmulatorModel.hpp"
+#include "fdreadoutlibs/tde/TDECrateSourceEmulatorModel.hpp"
 
 #include "fdreadoutlibs/FDReadoutTypes.hpp"
 #include "fdreadoutlibs/wib/TPEmulatorModel.hpp"
@@ -91,7 +91,7 @@ createSourceEmulator(const iomanager::connection::ConnectionRef qi, std::atomic<
   // IF TDE
   if (inst.find("tde") != std::string::npos) {
     auto source_emu_model =
-      std::make_unique<readoutlibs::TDECrateSourceEmulatorModel<fdreadoutlibs::types::TDE_AMC_STRUCT>>(
+      std::make_unique<fdreadoutlibs::TDECrateSourceEmulatorModel<fdreadoutlibs::types::TDE_AMC_STRUCT>>(
         qi.name, run_marker, tde_time_tick_diff, tde_dropout_rate, emu_frame_error_rate, tde_rate_khz);
     return source_emu_model;
   }


### PR DESCRIPTION
This PR adds the code to create a TDE readout system and the corresponding emulator. The timestamp difference is set to 1000 for testing purposes until we know its real value

TODO:
- Add support for the 12b frame format
- Fix the correct value of the timestamp when it is known