### PR TITLE
Fix and add options to standalone FW TP configuration generation

### DIFF
--- a/python/readoutmodules/app_confgen.py
+++ b/python/readoutmodules/app_confgen.py
@@ -32,6 +32,8 @@ def generate(
     NUMBER_OF_TP_PRODUCERS=1,
     DATA_RATE_SLOWDOWN_FACTOR=1,
     ENABLE_SOFTWARE_TPG=False,
+    CHANNEL_MAP_NAME="ProtoDUNESP1ChannelMap", 
+    FWTP_STITCH_CONSTANT=1600,
     RUN_NUMBER=333,
     DATA_FILE="./frames.bin",
     TP_DATA_FILE="./tp_frames.bin",
@@ -77,7 +79,7 @@ def generate(
         if ENABLE_SOFTWARE_TPG:
             queues += [Queue(f"datahandler_{idx}.tp_out",f"sw_tp_handler_{idx}.raw_input",f"sw_tp_link_{idx}",100000 )]                
                 
-        if FRONTEND_TYPE == 'wib':
+        if FRONTEND_TYPE == 'wib' and NUMBER_OF_DATA_PRODUCERS != 0:
             queues += [Queue(f"datahandler_{idx}.errored_frames", 'errored_frame_consumer.input_queue', "errored_frames_q", 10000)]
 
         modules += [DAQModule(name=f"datahandler_{idx}", plugin="DataLinkHandler", conf=rconf.Conf(
@@ -100,6 +102,8 @@ def generate(
                         region_id=0,
                         element_id=idx,
                         enable_software_tpg=ENABLE_SOFTWARE_TPG,
+                        channel_map_name=CHANNEL_MAP_NAME,
+                        fwtp_stitch_constant=FWTP_STITCH_CONSTANT,
                         error_counter_threshold=100,
                         error_reset_freq=10000,
                     ),
@@ -138,6 +142,8 @@ def generate(
                         region_id=0,
                         element_id=idx,
                         enable_software_tpg=ENABLE_SOFTWARE_TPG,
+                        channel_map_name=CHANNEL_MAP_NAME,
+                        fwtp_stitch_constant=FWTP_STITCH_CONSTANT,
                     ),
                     requesthandlerconf=rconf.RequestHandlerConf(
                         latency_buffer_size=3
@@ -173,6 +179,8 @@ def generate(
                         region_id=0,
                         element_id=idx,
                         enable_software_tpg=ENABLE_SOFTWARE_TPG,
+                        channel_map_name=CHANNEL_MAP_NAME,
+                        fwtp_stitch_constant=FWTP_STITCH_CONSTANT,
                     ),
                     requesthandlerconf=rconf.RequestHandlerConf(
                         latency_buffer_size=3
@@ -192,7 +200,7 @@ def generate(
     modules += [DAQModule(name="timesync_consumer", plugin="TimeSyncConsumer")]
     modules += [DAQModule(name="fragment_consumer", plugin="FragmentConsumer")]
 
-    if FRONTEND_TYPE == 'wib':
+    if FRONTEND_TYPE == 'wib' and NUMBER_OF_DATA_PRODUCERS != 0:
         modules += [DAQModule(name="errored_frame_consumer", plugin="ErroredFrameConsumer")]
 
     mgraph = ModuleGraph(modules, queues=queues)

--- a/scripts/readoutapp_gen
+++ b/scripts/readoutapp_gen
@@ -31,6 +31,8 @@ import click
 @click.option("-t", "--number-of-tp-producers", default=0)
 @click.option("-s", "--data-rate-slowdown-factor", default=10)
 @click.option("-g", "--enable-software-tpg", is_flag=True)
+@click.option("-m", "--channel-map-name", default="ProtoDUNESP1ChannelMap")
+@click.option("-c", "--fwtp_stitch_constant", default=1600)
 @click.option("-d", "--data-file", type=click.Path(), default="./frames.bin")
 @click.option("--tp-data-file", type=click.Path(), default="./tp_frames.bin")
 @click.option(
@@ -56,6 +58,8 @@ def cli(
     number_of_tp_producers,
     data_rate_slowdown_factor,
     enable_software_tpg,
+    channel_map_name,
+    fwtp_stitch_constant,
     data_file,
     tp_data_file,
     opmon_impl,


### PR DESCRIPTION
Following Pierre's fix for the new boot configuration, this PR is to
1) fix error he reported when running `nanorc` with the configuration from
```
readoutapp_gen -n 0 -t 1 tpapp.json
```
and a `tp_frames.bin` file from 
https://cernbox.cern.ch/index.php/s/zaOYX1tPT4cG3Fx

2) add options to set, a) the offline channel map name, and b) a constant for the stitching algorithm, from the command line.

This standalone readout  configuration generation was tested and works with the following setup 
```
source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest-spack
dbt-create -b candidate -c rc-dunedaq-v3.1.0-1 test_area
cd test_area
cd sourcecode
git clone https://github.com/DUNE-DAQ/readoutmodules.git -b prep-release/dunedaq-v3.1.0
cd ..
dbt-workarea-env
dbt-build -j16
find . -name readoutapp_gen -type f -print
readoutapp_gen -n 0 -t 1 tpapp.json
``` 