### PR TITLE
Hristova/tp appconfgen fix

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -78,7 +78,7 @@ rm -Rf RunConf_1; nanorc tpapp.json test boot conf start_run 001 wait 10 stop_ru
 ```
 
 The fix in branch https://github.com/DUNE-DAQ/readoutmodules/tree/hristova/tp_appconfgen_fix
-allows the WIB2 configuration options to be used._
+allows the WIB2 configuration options to be used.
 
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,9 +67,13 @@ find . -name readoutapp_gen -type f -print
 readoutapp_gen -h
 ```
 
-4. Generate configuration (TP links only, WIB2 format)
+4a. WIB2
 ```
 readoutapp_gen -n 0 -t 1 -c 2048 -m VDColdboxChannelMap tpapp.json
+```
+4b. WIB1 (currently default)
+```
+readoutapp_gen -n 0 -t 1 tpapp.json
 ```
 
 5. Run test job with nanorc

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,6 +67,8 @@ find . -name readoutapp_gen -type f -print
 readoutapp_gen -h
 ```
 
+4. Generate configuration (TP links only, WIB2 format)
+
 4a. WIB2
 ```
 readoutapp_gen -n 0 -t 1 -c 2048 -m VDColdboxChannelMap tpapp.json

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,15 +38,49 @@ The produced hit rate should be around 100kHz.
 
 ## Enabling the fake TP source
 
-The FakeCardReader module is capable of reading raw WIB TP data by enabling the corresponding link 
-via configuration. Currently the fake TPs are read out from a binary file (with default location 
-at /tmp/tp_frames.bin) and parsed using the "RawWibTp" format.
+The FakeCardReader module is capable of reading raw WIB2 TP data by enabling the corresponding link 
+via configuration. In emulator mode, the fake TPs are read out from a binary file (with default location 
+at ./tp_frames.bin) and parsed using the "RawTp" format `detdataformats`.
 
 To get the "tp_frames.bin" TP data:
 
-    curl https://cernbox.cern.ch/index.php/s/nd201XOcMCmHpIX/download -o /tmp/tp_frames.bin
+    curl https://cernbox.cern.ch/index.php/s/FqMXxSpM3WjgeCN/download -o tp_frames.bin
 
-_Instructions on how to test the fake raw WIB TP readout will be provided here_
+_Instructions on how to test the fake raw WIB TP readout will be provided/updated here:
+
+Testing TP standalone configuration script with dunedaq-v3.1.0:
+
+1. Download tp_frames.bin file
+```
+curl https://cernbox.cern.ch/index.php/s/FqMXxSpM3WjgeCN/download -o tp_frames.bin
+```
+
+2. Setup v3.1.0 work area and checkout branch
+```
+git clone https://github.com/DUNE-DAQ/readoutmodules.git -b hristova/tp_appconfgen_fix
+dbt-build -j16
+```
+
+3. Check TP standalone configuration script was installed
+```
+find . -name readoutapp_gen -type f -print
+readoutapp_gen -h
+```
+
+4. Generate configuration (TP links only, WIB2 format)
+```
+readoutapp_gen -n 0 -t 1 -c 2048 -m VDColdboxChannelMap tpapp.json
+```
+
+5. Run test job with nanorc
+```
+rm -Rf RunConf_1; nanorc tpapp.json test boot conf start_run 001 wait 10 stop_run scrap terminate
+```
+
+The fix in branch https://github.com/DUNE-DAQ/readoutmodules/tree/hristova/tp_appconfgen_fix
+allows the WIB2 configuration options to be used._
+
+
 
 ## Modules provided by readoutmodules
 `readoutmodules` provides several `DAQModule`s that are listed here:

--- a/scripts/readoutapp_gen
+++ b/scripts/readoutapp_gen
@@ -123,6 +123,8 @@ def cli(
     NUMBER_OF_TP_PRODUCERS=number_of_tp_producers,
     DATA_RATE_SLOWDOWN_FACTOR=data_rate_slowdown_factor,
     ENABLE_SOFTWARE_TPG=enable_software_tpg,
+    CHANNEL_MAP_NAME=channel_map_name,
+    FWTP_STITCH_CONSTANT=fwtp_stitch_constant,
     DATA_FILE=data_file,
     TP_DATA_FILE=tp_data_file,
     HOST=host)


### PR DESCRIPTION
This PR conatins the following related changes: 
1. Updated README to describe procedure for running firmware TPG with emulated source (tp_frames.bin) 
2. Fixed standalone configuration generation script to enable options that set the channel map files and the tp stitching constant  

The changes are minor and self-contained. It would be good to include them in develop or the next patch release branch.