### PR TITLE
Make the raw TP frame unpacking configurable

### DIFF
--- a/python/readoutmodules/app_confgen.py
+++ b/python/readoutmodules/app_confgen.py
@@ -34,6 +34,7 @@ def generate(
     ENABLE_SOFTWARE_TPG=False,
     CHANNEL_MAP_NAME="ProtoDUNESP1ChannelMap", 
     FWTP_STITCH_CONSTANT=1600,
+    FWTP_FORMAT_VERSION=1,
     RUN_NUMBER=333,
     DATA_FILE="./frames.bin",
     TP_DATA_FILE="./tp_frames.bin",
@@ -104,6 +105,7 @@ def generate(
                         enable_software_tpg=ENABLE_SOFTWARE_TPG,
                         channel_map_name=CHANNEL_MAP_NAME,
                         fwtp_stitch_constant=FWTP_STITCH_CONSTANT,
+                        fwtp_format_version=FWTP_FORMAT_VERSION,
                         error_counter_threshold=100,
                         error_reset_freq=10000,
                     ),
@@ -144,6 +146,7 @@ def generate(
                         enable_software_tpg=ENABLE_SOFTWARE_TPG,
                         channel_map_name=CHANNEL_MAP_NAME,
                         fwtp_stitch_constant=FWTP_STITCH_CONSTANT,
+                        fwtp_format_version=FWTP_FORMAT_VERSION,
                     ),
                     requesthandlerconf=rconf.RequestHandlerConf(
                         latency_buffer_size=3
@@ -181,6 +184,7 @@ def generate(
                         enable_software_tpg=ENABLE_SOFTWARE_TPG,
                         channel_map_name=CHANNEL_MAP_NAME,
                         fwtp_stitch_constant=FWTP_STITCH_CONSTANT,
+                        fwtp_format_version=FWTP_FORMAT_VERSION,
                     ),
                     requesthandlerconf=rconf.RequestHandlerConf(
                         latency_buffer_size=3

--- a/scripts/readoutapp_gen
+++ b/scripts/readoutapp_gen
@@ -33,7 +33,7 @@ import click
 @click.option("-g", "--enable-software-tpg", is_flag=True)
 @click.option("-m", "--channel-map-name", default="ProtoDUNESP1ChannelMap")
 @click.option("-c", "--fwtp_stitch_constant", default=1600)
-@click.option("-v", "--fwtp_format_version", default=1600)
+@click.option("-v", "--fwtp_format_version", default=1)
 @click.option("-d", "--data-file", type=click.Path(), default="./frames.bin")
 @click.option("--tp-data-file", type=click.Path(), default="./tp_frames.bin")
 @click.option(

--- a/scripts/readoutapp_gen
+++ b/scripts/readoutapp_gen
@@ -33,6 +33,7 @@ import click
 @click.option("-g", "--enable-software-tpg", is_flag=True)
 @click.option("-m", "--channel-map-name", default="ProtoDUNESP1ChannelMap")
 @click.option("-c", "--fwtp_stitch_constant", default=1600)
+@click.option("-v", "--fwtp_format_version", default=1600)
 @click.option("-d", "--data-file", type=click.Path(), default="./frames.bin")
 @click.option("--tp-data-file", type=click.Path(), default="./tp_frames.bin")
 @click.option(
@@ -60,6 +61,7 @@ def cli(
     enable_software_tpg,
     channel_map_name,
     fwtp_stitch_constant,
+    fwtp_format_version,
     data_file,
     tp_data_file,
     opmon_impl,
@@ -125,6 +127,7 @@ def cli(
     ENABLE_SOFTWARE_TPG=enable_software_tpg,
     CHANNEL_MAP_NAME=channel_map_name,
     FWTP_STITCH_CONSTANT=fwtp_stitch_constant,
+    FWTP_FORMAT_VERSION=fwtp_format_version,
     DATA_FILE=data_file,
     TP_DATA_FILE=tp_data_file,
     HOST=host)


### PR DESCRIPTION
This PR adds the option to configure the unpacking of the raw TP frames according to the firmware TPG format. Currently 
we have two fwTGP format versions, which we call "old" and "new", or alternatively, we can refer to them as "v1" and "v2".
This feature involves changes in the following packages (where the relevant PRs are made as well):
fdreadoutlibs
readoutlibs
readoutmodules  (here)
https://github.com/DUNE-DAQ/fdreadoutlibs/pull/46
https://github.com/DUNE-DAQ/readoutlibs/pull/49
https://github.com/DUNE-DAQ/readoutmodules/pull/28

The new TP format was implemented in firmware as a response to a request we made from the readout side, and it makes the unpacking more straightforward in software, because the TP header explicitly contains the number of hits. 

This corresponds to issue: https://github.com/DUNE-DAQ/fdreadoutlibs/issues/26