### PR TITLE
Hristova/tp format config v3.2.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,12 +52,13 @@ Testing TP standalone configuration script with dunedaq-v3.1.0:
 
 1. Download tp_frames.bin file
 ```
-curl https://cernbox.cern.ch/index.php/s/FqMXxSpM3WjgeCN/download -o tp_frames.bin
+curl https://cernbox.cern.ch/index.php/s/asyh9lHd8PhxMyI -o tp_frames.bin (old TP format, version 1)
+curl https://cernbox.cern.ch/index.php/s/QRBAANbBQNbhuYC -o tp_frames.bin (new TP format, version 2)
 ```
 
-2. Setup v3.1.0 work area and checkout branch
+2. Setup v3.2.0 development work area and checkout branch
 ```
-git clone https://github.com/DUNE-DAQ/readoutmodules.git -b hristova/tp_appconfgen_fix
+git clone https://github.com/DUNE-DAQ/readoutmodules.git -b hristova/tp_format_config_v3.2.0
 dbt-build -j16
 ```
 
@@ -69,23 +70,21 @@ readoutapp_gen -h
 
 4. Generate configuration (TP links only, WIB2 format)
 
-4a. WIB2
+4a. WIB2 (currently default)
 ```
-readoutapp_gen -n 0 -t 1 -c 2048 -m VDColdboxChannelMap tpapp.json
+readoutapp_gen -n 0 -t 1 -m VDColdboxChannelMap tpapp.json (old TP format, version 1: default)
+readoutapp_gen -n 0 -t 1 -v 2 -m VDColdboxChannelMap tpapp_v2.json (new TP format, version 2)
 ```
-4b. WIB1 (currently default)
+4b. WIB1 
 ```
-readoutapp_gen -n 0 -t 1 tpapp.json
+readoutapp_gen -n 0 -t 1 -c 1600 -m VDColdboxChannelMap tpapp.json (old TP format, version 1: default)
+readoutapp_gen -n 0 -t 1 -v 2 -c 1600 -m VDColdboxChannelMap tpapp_v2.json (new TP format, version 2)
 ```
 
 5. Run test job with nanorc
 ```
 rm -Rf RunConf_1; nanorc tpapp.json test boot conf start_run 001 wait 10 stop_run scrap terminate
 ```
-
-The fix in branch https://github.com/DUNE-DAQ/readoutmodules/tree/hristova/tp_appconfgen_fix
-allows the WIB2 configuration options to be used.
-
 
 
 ## Modules provided by readoutmodules

--- a/python/readoutmodules/app_confgen.py
+++ b/python/readoutmodules/app_confgen.py
@@ -58,7 +58,8 @@ def generate(
                             source_id =  link.dro_source_id,
                             slowdown=DATA_RATE_SLOWDOWN_FACTOR,
                             queue_name=f"output_{link.dro_source_id}",
-                            data_filename=TP_DATA_FILE,
+                            data_filename=DATA_FILE,
+                            tp_data_filename=TP_DATA_FILE,
                             emu_frame_error_rate=0,
                         )
                         for link in DRO_CONFIG.links],

--- a/python/readoutmodules/app_confgen.py
+++ b/python/readoutmodules/app_confgen.py
@@ -19,6 +19,7 @@ import dunedaq.readoutlibs.recorderconfig as bfs
 from daqconf.core.app import App, ModuleGraph
 from daqconf.core.daqmodule import DAQModule
 from daqconf.core.conf_utils import Endpoint, Direction, Queue
+from daqconf.core.sourceid import TPInfo, SourceIDBroker
 
 # Time to waait on pop()
 QUEUE_POP_WAIT_MS = 100
@@ -27,85 +28,66 @@ CLOCK_SPEED_HZ = 50000000
 
 
 def generate(
-    FRONTEND_TYPE="wib",
+    DRO_CONFIG=None,
+    SOURCEID_BROKER=None,
+    FRONTEND_TYPE="raw_tp",
     NUMBER_OF_DATA_PRODUCERS=1,
     NUMBER_OF_TP_PRODUCERS=1,
     DATA_RATE_SLOWDOWN_FACTOR=1,
     ENABLE_SOFTWARE_TPG=False,
     CHANNEL_MAP_NAME="ProtoDUNESP1ChannelMap", 
-    FWTP_STITCH_CONSTANT=1600,
+    FWTP_STITCH_CONSTANT=2048,
+    FWTP_FORMAT_VERSION=1,
     RUN_NUMBER=333,
     DATA_FILE="./frames.bin",
     TP_DATA_FILE="./tp_frames.bin",
-    HOST="localhost"
+    HOST="localhost",
+    READOUT_SENDS_TP_FRAGMENTS=False,
 ):
 
     modules = []
     queues = []
 
+    host = DRO_CONFIG.host.replace("-","_")
+    RUIDX = f"{host}_{DRO_CONFIG.card}"
+
     modules += [DAQModule(name="fake_source", plugin="FakeCardReader", conf=sec.Conf(
                     link_confs=[
                         sec.LinkConfiguration(
-                            geoid=sec.GeoID(system="TPC", region=0, element=idx),
+                            source_id =  link.dro_source_id,
                             slowdown=DATA_RATE_SLOWDOWN_FACTOR,
-                            queue_name=f"output_{idx}",
-                            data_filename=DATA_FILE,
+                            queue_name=f"output_{link.dro_source_id}",
+                            data_filename=TP_DATA_FILE,
                             emu_frame_error_rate=0,
                         )
-                        for idx in range(NUMBER_OF_DATA_PRODUCERS)
-                    ]
-                    + [
-                        sec.LinkConfiguration(
-                            geoid=sec.GeoID(system="TPC", region=0, element=idx),
-                            slowdown=DATA_RATE_SLOWDOWN_FACTOR,
-                            queue_name=f"output_raw_tp_{idx}",
-                            tp_data_filename=TP_DATA_FILE,
-                            emu_frame_error_rate=0,
-                        )
-                        for idx in range(
-                            NUMBER_OF_DATA_PRODUCERS,
-                            NUMBER_OF_DATA_PRODUCERS + NUMBER_OF_TP_PRODUCERS,
-                        )
-                    ],
+                        for link in DRO_CONFIG.links],
                     # input_limit=10485100, # default
-                    queue_timeout_ms=QUEUE_POP_WAIT_MS,
-                    set_t0_to=0,
-                ))]
+                    queue_timeout_ms=QUEUE_POP_WAIT_MS
+            ))]
 
-    queues += [Queue(f"fake_source.output_{idx}",f"datahandler_{idx}.raw_input",f'{FRONTEND_TYPE}_link_{idx}', 100000) for idx in range(NUMBER_OF_DATA_PRODUCERS)]
-    queues += [Queue(f"fake_source.output_raw_tp_{idx}",f"raw_tp_handler_{idx}.raw_input",f'raw_tp_link_{idx}', 100000) for idx in range(NUMBER_OF_DATA_PRODUCERS + NUMBER_OF_TP_PRODUCERS)]
-
-    for idx in range(NUMBER_OF_DATA_PRODUCERS):
-        if ENABLE_SOFTWARE_TPG:
-            queues += [Queue(f"datahandler_{idx}.tp_out",f"sw_tp_handler_{idx}.raw_input",f"sw_tp_link_{idx}",100000 )]                
-                
-        if FRONTEND_TYPE == 'wib' and NUMBER_OF_DATA_PRODUCERS != 0:
-            queues += [Queue(f"datahandler_{idx}.errored_frames", 'errored_frame_consumer.input_queue', "errored_frames_q", 10000)]
-
-        modules += [DAQModule(name=f"datahandler_{idx}", plugin="DataLinkHandler", conf=rconf.Conf(
+    queues += [Queue(f"fake_source.output_{link.dro_source_id}",f"raw_tp_handler_{link.dro_source_id}.raw_input",f'{FRONTEND_TYPE}_link_{link.dro_source_id}', 100000) for link in DRO_CONFIG.links]
+   
+    for link in DRO_CONFIG.links: 
+        modules += [DAQModule(name=f"raw_tp_handler_{link.dro_source_id}", plugin="DataLinkHandler", conf=rconf.Conf(
                     readoutmodelconf=rconf.ReadoutModelConf(
+			source_id = link.dro_source_id,
                         source_queue_timeout_ms=QUEUE_POP_WAIT_MS,
                         fake_trigger_flag=1,
-                        region_id=0,
-                        element_id=idx,
-                        timesync_connection_name = f"timesync_dlh_{idx}",
+                        timesync_connection_name = f"timesync_{link.dro_source_id}",
                         timesync_topic_name = "Timesync",
                     ),
                     latencybufferconf=rconf.LatencyBufferConf(
                         latency_buffer_size=3
                         * CLOCK_SPEED_HZ
                         / (25 * 12 * DATA_RATE_SLOWDOWN_FACTOR),
-                        region_id=0,
-                        element_id=idx,
+                        source_id = link.dro_source_id,
                     ),
                     rawdataprocessorconf=rconf.RawDataProcessorConf(
-                        region_id=0,
-                        element_id=idx,
+                        source_id = link.dro_source_id,
                         enable_software_tpg=ENABLE_SOFTWARE_TPG,
                         channel_map_name=CHANNEL_MAP_NAME,
                         fwtp_stitch_constant=FWTP_STITCH_CONSTANT,
-                        error_counter_threshold=100,
-                        error_reset_freq=10000,
+                        fwtp_format_version=FWTP_FORMAT_VERSION,
                     ),
                     requesthandlerconf=rconf.RequestHandlerConf(
                         latency_buffer_size=3
@@ -113,116 +95,26 @@ def generate(
                         / (25 * 12 * DATA_RATE_SLOWDOWN_FACTOR),
                         pop_limit_pct=0.8,
                         pop_size_pct=0.1,
-                        region_id=0,
-                        element_id=idx,
-                        output_file=f"output_{idx}.out",
+                        source_id = link.dro_source_id,
+                        output_file=f"output_raw_tp_{link.dro_source_id}.out",
                         stream_buffer_size=8388608,
                         enable_raw_recording=True,
                     ),
-                ), extra_commands={"record": rconf.RecordingParams(duration=10)})]
-
-        if ENABLE_SOFTWARE_TPG:
-            modules += [DAQModule(name=f"sw_tp_handler_{idx}", plugin="DataLinkHandler", conf=rconf.Conf(
-                    readoutmodelconf=rconf.ReadoutModelConf(
-                        source_queue_timeout_ms=QUEUE_POP_WAIT_MS,
-                        fake_trigger_flag=1,
-                        region_id=0,
-                        element_id=idx,
-                        timesync_connection_name = f"timesync_tp_dlh_{idx}",
-                        timesync_topic_name = "Timesync",
-                    ),
-                    latencybufferconf=rconf.LatencyBufferConf(
-                        latency_buffer_size=3
-                        * CLOCK_SPEED_HZ
-                        / (25 * 12 * DATA_RATE_SLOWDOWN_FACTOR),
-                        region_id=0,
-                        element_id=idx,
-                    ),
-                    rawdataprocessorconf=rconf.RawDataProcessorConf(
-                        region_id=0,
-                        element_id=idx,
-                        enable_software_tpg=ENABLE_SOFTWARE_TPG,
-                        channel_map_name=CHANNEL_MAP_NAME,
-                        fwtp_stitch_constant=FWTP_STITCH_CONSTANT,
-                    ),
-                    requesthandlerconf=rconf.RequestHandlerConf(
-                        latency_buffer_size=3
-                        * CLOCK_SPEED_HZ
-                        / (25 * 12 * DATA_RATE_SLOWDOWN_FACTOR),
-                        pop_limit_pct=0.8,
-                        pop_size_pct=0.1,
-                        region_id=0,
-                        element_id=idx,
-                        output_file=f"output_{idx}.out",
-                        stream_buffer_size=8388608,
-                        enable_raw_recording=False,
-                    ),
                 ))]
-
-    modules += [DAQModule(name=f"raw_tp_handler_{idx}", plugin="DataLinkHandler", conf=rconf.Conf(
-                    readoutmodelconf=rconf.ReadoutModelConf(
-                        source_queue_timeout_ms=QUEUE_POP_WAIT_MS,
-                        fake_trigger_flag=1,
-                        region_id=0,
-                        element_id=idx,
-                        timesync_connection_name = f"timesync_rtp_{idx}",
-                        timesync_topic_name = "Timesync",
-                    ),
-                    latencybufferconf=rconf.LatencyBufferConf(
-                        latency_buffer_size=3
-                        * CLOCK_SPEED_HZ
-                        / (25 * 12 * DATA_RATE_SLOWDOWN_FACTOR),
-                        region_id=0,
-                        element_id=idx,
-                    ),
-                    rawdataprocessorconf=rconf.RawDataProcessorConf(
-                        region_id=0,
-                        element_id=idx,
-                        enable_software_tpg=ENABLE_SOFTWARE_TPG,
-                        channel_map_name=CHANNEL_MAP_NAME,
-                        fwtp_stitch_constant=FWTP_STITCH_CONSTANT,
-                    ),
-                    requesthandlerconf=rconf.RequestHandlerConf(
-                        latency_buffer_size=3
-                        * CLOCK_SPEED_HZ
-                        / (25 * 12 * DATA_RATE_SLOWDOWN_FACTOR),
-                        pop_limit_pct=0.8,
-                        pop_size_pct=0.1,
-                        region_id=0,
-                        element_id=idx,
-                        output_file=f"output_raw_tp_{idx}.out",
-                        stream_buffer_size=8388608,
-                        enable_raw_recording=True,
-                    ),
-                ))
-            for idx in range(NUMBER_OF_DATA_PRODUCERS, NUMBER_OF_DATA_PRODUCERS + NUMBER_OF_TP_PRODUCERS)]
 
     modules += [DAQModule(name="timesync_consumer", plugin="TimeSyncConsumer")]
     modules += [DAQModule(name="fragment_consumer", plugin="FragmentConsumer")]
 
-    if FRONTEND_TYPE == 'wib' and NUMBER_OF_DATA_PRODUCERS != 0:
-        modules += [DAQModule(name="errored_frame_consumer", plugin="ErroredFrameConsumer")]
-
     mgraph = ModuleGraph(modules, queues=queues)
-    for idx in range(NUMBER_OF_DATA_PRODUCERS):
 
-        if ENABLE_SOFTWARE_TPG:
-            mgraph.connect_modules(f"tp_datahandler_{idx}.timesync_output", "timesync_consumer.input_queue", "timesync_q")
-            mgraph.connect_modules(f"tp_datahandler_{idx}.fragment_queue", "fragment_consumer.input_queue", "data_fragments_q", 100)
-            mgraph.add_endpoint(f"tp_requests_{idx}", f"tp_datahandler_{idx}.request_input", Direction.IN)
-            mgraph.add_endpoint(f"tp_requests_{idx}", None, Direction.OUT) # Fake request endpoint
-        
-        mgraph.connect_modules(f"datahandler_{idx}.timesync_output", "timesync_consumer.input_queue", "timesync_q")
-        mgraph.connect_modules(f"datahandler_{idx}.fragment_queue", "fragment_consumer.input_queue", "data_fragments_q", 100)
-        mgraph.add_endpoint(f"requests_{idx}", f"datahandler_{idx}.request_input", Direction.IN)
-        mgraph.add_endpoint(f"requests_{idx}", None, Direction.OUT) # Fake request endpoint
-
-
-    for idx in range(NUMBER_OF_DATA_PRODUCERS, NUMBER_OF_DATA_PRODUCERS + NUMBER_OF_TP_PRODUCERS):
-        mgraph.connect_modules(f"raw_tp_handler_{idx}.timesync_output", "timesync_consumer.input_queue", "timesync_q")
-        mgraph.connect_modules(f"raw_tp_handler_{idx}.fragment_queue", "fragment_consumer.input_queue", "data_fragments_q", 100)
-        mgraph.add_endpoint(f"rtp_requests_{idx}", f"raw_tp_handler_{idx}.request_input", Direction.IN)
-        mgraph.add_endpoint(f"rtp_requests_{idx}", None, Direction.OUT) # Fake request endpoint
+    for link in DRO_CONFIG.links:
+        mgraph.add_fragment_producer(id = link.dro_source_id, subsystem = "Detector Readout",
+            requests_in   = f"raw_tp_handler_{link.dro_source_id}.request_input",
+            fragments_out = f"raw_tp_handler_{link.dro_source_id}.fragment_queue")
+        mgraph.connect_modules(f"raw_tp_handler_{link.dro_source_id}.timesync_output", "timesync_consumer.input_queue", "timesync_q")
+        mgraph.connect_modules(f"raw_tp_handler_{link.dro_source_id}.fragment_queue", "fragment_consumer.input_queue", "data_fragments_q", 100)
+        mgraph.add_endpoint(f"rtp_requests_{link.dro_source_id}", f"raw_tp_handler_{link.dro_source_id}.request_input", Direction.IN)
+        mgraph.add_endpoint(f"rtp_requests_{link.dro_source_id}", None, Direction.OUT) # Fake request endpoint
         
     ru_app = App(modulegraph=mgraph, host=HOST, name="readout_app")
     return ru_app

--- a/python/readoutmodules/app_confgen.py
+++ b/python/readoutmodules/app_confgen.py
@@ -35,6 +35,7 @@ def generate(
     NUMBER_OF_TP_PRODUCERS=1,
     DATA_RATE_SLOWDOWN_FACTOR=1,
     ENABLE_SOFTWARE_TPG=False,
+    ENABLE_FIRMWARE_TPG=False,
     CHANNEL_MAP_NAME="ProtoDUNESP1ChannelMap", 
     FWTP_STITCH_CONSTANT=2048,
     FWTP_FORMAT_VERSION=1,
@@ -85,6 +86,7 @@ def generate(
                     rawdataprocessorconf=rconf.RawDataProcessorConf(
                         source_id = link.dro_source_id,
                         enable_software_tpg=ENABLE_SOFTWARE_TPG,
+                        enable_firmware_tpg=ENABLE_FIRMWARE_TPG,
                         channel_map_name=CHANNEL_MAP_NAME,
                         fwtp_stitch_constant=FWTP_STITCH_CONSTANT,
                         fwtp_format_version=FWTP_FORMAT_VERSION,

--- a/scripts/readoutapp_gen
+++ b/scripts/readoutapp_gen
@@ -11,6 +11,7 @@ from os.path import exists, join
 from daqconf.core.system import System
 from daqconf.core.conf_utils import make_app_command_data
 from daqconf.core.metadata import write_metadata_file
+from daqconf.core.sourceid import *
 
 # Add -h as default help option
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
@@ -33,6 +34,7 @@ import click
 @click.option("-g", "--enable-software-tpg", is_flag=True)
 @click.option("-m", "--channel-map-name", default="ProtoDUNESP1ChannelMap")
 @click.option("-c", "--fwtp_stitch_constant", default=1600)
+@click.option("-v", "--fwtp_format_version", default=1)
 @click.option("-d", "--data-file", type=click.Path(), default="./frames.bin")
 @click.option("--tp-data-file", type=click.Path(), default="./tp_frames.bin")
 @click.option(
@@ -60,6 +62,7 @@ def cli(
     enable_software_tpg,
     channel_map_name,
     fwtp_stitch_constant,
+    fwtp_format_version,
     data_file,
     tp_data_file,
     opmon_impl,
@@ -74,6 +77,18 @@ def cli(
 
     console.log("Loading app_confgen config generator")
     from readoutmodules import app_confgen
+
+    #hw_map_service = HardwareMapService(hardware_map_file)
+    hw_map_service = HardwareMapService("my_hw_map.txt")
+    dro_infos = hw_map_service.get_all_dro_info()
+    sourceid_broker = SourceIDBroker()
+    #sourceid_broker.debug = debug
+    sourceid_broker.register_readout_source_ids(dro_infos)
+    tp_mode = get_tpg_mode(TPGenMode.FWTPG,False)
+    sourceid_broker.generate_trigger_source_ids(dro_infos, tp_mode)
+    tp_infos = sourceid_broker.get_all_source_ids("Trigger")
+    for dro_info in dro_infos:
+        console.log(f"Will start a RU process on {dro_info.host} reading card number {dro_info.card}, {len(dro_info.links)} links active")
 
     the_system = System()
 
@@ -118,6 +133,7 @@ def cli(
         ers_settings["FATAL"] = "erstrace,lstdout"
 
     # add app
+    '''
     the_system.apps["readout_app"] = app_confgen.generate(FRONTEND_TYPE=frontend_type,
     NUMBER_OF_DATA_PRODUCERS=number_of_data_producers,
     NUMBER_OF_TP_PRODUCERS=number_of_tp_producers,
@@ -125,9 +141,28 @@ def cli(
     ENABLE_SOFTWARE_TPG=enable_software_tpg,
     CHANNEL_MAP_NAME=channel_map_name,
     FWTP_STITCH_CONSTANT=fwtp_stitch_constant,
+    FWTP_FORMAT_VERSION=fwtp_format_version,
     DATA_FILE=data_file,
     TP_DATA_FILE=tp_data_file,
     HOST=host)
+    '''
+    ru_app_names=[]
+    for dro_idx,dro_config in enumerate(dro_infos):
+        host=dro_config.host.replace("-","")
+        ru_name = f"ru{host}{dro_config.card}"
+        ru_app_names.append(ru_name)
+        the_system.apps[ru_name] = app_confgen.generate(
+            HOST=dro_config.host,
+            DRO_CONFIG=dro_config,
+            SOURCEID_BROKER = sourceid_broker,
+            DATA_RATE_SLOWDOWN_FACTOR=data_rate_slowdown_factor,
+            ENABLE_SOFTWARE_TPG=enable_software_tpg,
+            CHANNEL_MAP_NAME=channel_map_name,
+            FWTP_STITCH_CONSTANT=fwtp_stitch_constant,
+            FWTP_FORMAT_VERSION=fwtp_format_version,
+            DATA_FILE=data_file,
+            TP_DATA_FILE=tp_data_file)
+
 
     ####################################################################
     # Application command data generation
@@ -174,7 +209,7 @@ def cli(
 
     console.log(f"Readout app config generated in {json_dir}")
 
-    write_metadata_file(json_dir, "readoutapp_gen")
+    write_metadata_file(json_dir, "readoutapp_gen", "./daqconf.ini")
 
 
 if __name__ == "__main__":

--- a/scripts/readoutapp_gen
+++ b/scripts/readoutapp_gen
@@ -32,6 +32,7 @@ import click
 @click.option("-t", "--number-of-tp-producers", default=0)
 @click.option("-s", "--data-rate-slowdown-factor", default=10)
 @click.option("-g", "--enable-software-tpg", is_flag=True)
+@click.option("-f", "--enable-firmware-tpg", is_flag=True)
 @click.option("-m", "--channel-map-name", default="ProtoDUNESP1ChannelMap")
 @click.option("-c", "--fwtp_stitch_constant", default=1600)
 @click.option("-v", "--fwtp_format_version", default=1)
@@ -60,6 +61,7 @@ def cli(
     number_of_tp_producers,
     data_rate_slowdown_factor,
     enable_software_tpg,
+    enable_firmware_tpg,
     channel_map_name,
     fwtp_stitch_constant,
     fwtp_format_version,
@@ -139,6 +141,7 @@ def cli(
     NUMBER_OF_TP_PRODUCERS=number_of_tp_producers,
     DATA_RATE_SLOWDOWN_FACTOR=data_rate_slowdown_factor,
     ENABLE_SOFTWARE_TPG=enable_software_tpg,
+    ENABLE_FIRMWARE_TPG=enable_firmware_tpg,
     CHANNEL_MAP_NAME=channel_map_name,
     FWTP_STITCH_CONSTANT=fwtp_stitch_constant,
     FWTP_FORMAT_VERSION=fwtp_format_version,
@@ -157,6 +160,7 @@ def cli(
             SOURCEID_BROKER = sourceid_broker,
             DATA_RATE_SLOWDOWN_FACTOR=data_rate_slowdown_factor,
             ENABLE_SOFTWARE_TPG=enable_software_tpg,
+            ENABLE_FIRMWARE_TPG=enable_firmware_tpg,
             CHANNEL_MAP_NAME=channel_map_name,
             FWTP_STITCH_CONSTANT=fwtp_stitch_constant,
             FWTP_FORMAT_VERSION=fwtp_format_version,


### PR DESCRIPTION
This PR replaces https://github.com/DUNE-DAQ/readoutmodules/pull/28
It is indeded to merge to develop for dunedaq-v3.2.0

Here we add the option to configure the unpacking of the raw TP frames according to the firmware TPG format. Currently
we have two fwTGP format versions, which we call "old" and "new", or alternatively, we can refer to them as "v1" and "v2".
This feature involves changes in the following packages (where the relevant PRs are made as well):
fdreadoutlibs
readoutlibs
readoutmodules (here)