### PR TITLE
Make FW TP processor accessible via wib2

### DIFF
--- a/src/CreateReadout.hpp
+++ b/src/CreateReadout.hpp
@@ -27,7 +27,7 @@
 #include "fdreadoutlibs/daphne/DAPHNEFrameProcessor.hpp"
 #include "fdreadoutlibs/daphne/DAPHNEListRequestHandler.hpp"
 #include "fdreadoutlibs/ssp/SSPFrameProcessor.hpp"
-#include "fdreadoutlibs/wib/RAWWIBTriggerPrimitiveProcessor.hpp"
+#include "fdreadoutlibs/wib2/RAWWIBTriggerPrimitiveProcessor.hpp"
 #include "fdreadoutlibs/wib/SWWIBTriggerPrimitiveProcessor.hpp"
 #include "fdreadoutlibs/wib/WIBFrameProcessor.hpp"
 #include "fdreadoutlibs/wib2/WIB2FrameProcessor.hpp"


### PR DESCRIPTION
There were two firmware TP processors, each in wib and wib2 directories.
The firmware TP now supports WIB2 only, the DUNE-WIB.
Enable access to RAWWIBTriggerPrimitiveProcessor from the wib2 location by adding it to src/FDReadoutlibs.cpp
and removing access from wib directory.