### PR TITLE
Removed an std::move call in a return statement in CreateReadout

### DIFF
--- a/src/CreateReadout.hpp
+++ b/src/CreateReadout.hpp
@@ -151,7 +151,7 @@ createReadout(const nlohmann::json& args, std::atomic<bool>& run_marker)
           rol::SkipListLatencyBufferModel<fdt::DUNEWIBFirmwareTriggerPrimitiveSuperChunkTypeAdapter>,
           fdl::RAWWIBTriggerPrimitiveProcessor>>(run_marker);
         readout_model->init(args);
-        return std::move(readout_model);
+        return readout_model;
       }
 
       // IF ND LAr PACMAN


### PR DESCRIPTION
…::createReadout, as suggested by a gcc 12 compiler warning.